### PR TITLE
Fix `StackOverflowException` in `CalledFaction` and correct mental state duration scaling

### DIFF
--- a/1.5/Source/HautsFramework/Class1.cs
+++ b/1.5/Source/HautsFramework/Class1.cs
@@ -9431,7 +9431,7 @@ namespace HautsFramework
         }
         public Faction CalledFaction { 
             get {
-                return this.CalledFaction;
+                return this.calledFaction;
             } 
         }
         public virtual void AffectPawnInner(PermitMoreEffects pme, Pawn pawn, Faction faction)

--- a/1.5/Source/HautsFramework/Class1.cs
+++ b/1.5/Source/HautsFramework/Class1.cs
@@ -577,7 +577,7 @@ namespace HautsFramework
             if (pawn != null && pawn.Ideo == __instance.parent.pawn.Ideo && pawn.mindState != null && pawn.mindState.mentalStateHandler.CurStateDef == __instance.Props.stateDef)
             {
                 int newDuration = (int)(pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks * pawn.GetStatValue(HautsDefOf.Hauts_IdeoAbilityDurationSelf));
-                pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks *= newDuration;
+                pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks = newDuration;
             }
         }
         public static void HautsMaxDryadsPostfix(ref int __result, CompTreeConnection __instance)

--- a/1.6/Mods/Ideology/Source/HautsF_Ideology/HarmonyPatches.cs
+++ b/1.6/Mods/Ideology/Source/HautsF_Ideology/HarmonyPatches.cs
@@ -66,7 +66,7 @@ namespace HautsF_Ideology
             if (pawn != null && pawn.Ideo == __instance.parent.pawn.Ideo && pawn.mindState != null && pawn.mindState.mentalStateHandler.CurStateDef == __instance.Props.stateDef)
             {
                 int newDuration = (int)(pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks * pawn.GetStatValue(HautsDefOf.Hauts_IdeoAbilityDurationSelf));
-                pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks *= newDuration;
+                pawn.mindState.mentalStateHandler.CurState.forceRecoverAfterTicks = newDuration;
             }
         }
         //max dryad factor

--- a/1.6/Source/HautsFramework/PermitWorkers.cs
+++ b/1.6/Source/HautsFramework/PermitWorkers.cs
@@ -1529,7 +1529,7 @@ namespace HautsFramework
         {
             get
             {
-                return this.CalledFaction;
+                return this.calledFaction;
             }
         }
         public virtual void AffectPawnInner(PermitMoreEffects pme, Pawn pawn, Faction faction)


### PR DESCRIPTION
Resolves a runtime crash caused by infinite property recursion in `CalledFaction` and fixes compounding mental state durations when applying ideoligious abilities.

## Changes
- **Fix infinite recursion (`1.5` & `1.6`)**: Updated `CalledFaction` property getter in `RoyalTitlePermitWorker_TargetPawn` to return backing field `calledFaction` instead of self-referencing `CalledFaction`.
- **Fix mental state duration scaling (`1.5` & `1.6`)**: Updated `HautsGiveMentalStatePostfix` to assign `forceRecoverAfterTicks = newDuration` instead of multiplying `*=`, preventing mental state durations from compounding into hundreds of in-game days.